### PR TITLE
Enable dispatching date clicked event even if modifiers are pressed. Forward original BlClickEvent in the custom calendar event so client code can reason about modifiers if needed.

### DIFF
--- a/src/GToolkit-Completer/GtCalendarDateClickedEvent.class.st
+++ b/src/GToolkit-Completer/GtCalendarDateClickedEvent.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #GtCalendarDateClickedEvent,
 	#superclass : #BlEvent,
 	#instVars : [
-		'date'
+		'date',
+		'clickEvent'
 	],
 	#category : #'GToolkit-Completer-Calendar'
 }
@@ -12,6 +13,16 @@ GtCalendarDateClickedEvent class >> forDate: aDate [
 	^ (self new)
 		date: aDate;
 		yourself
+]
+
+{ #category : #accessing }
+GtCalendarDateClickedEvent >> clickEvent [
+	^ clickEvent
+]
+
+{ #category : #accessing }
+GtCalendarDateClickedEvent >> clickEvent: aBlClickEvent [
+	clickEvent := aBlClickEvent
 ]
 
 { #category : #accessing }

--- a/src/GToolkit-Completer/GtCalendarElement.class.st
+++ b/src/GToolkit-Completer/GtCalendarElement.class.st
@@ -32,7 +32,16 @@ GtCalendarElement >> buildDays [
 				padding: (BlInsets all: 1);
 				layout: BlLinearLayout horizontal alignCenter;
 				label: current dayOfMonth printString;
-				action: [ self dispatchEvent: (GtCalendarDateClickedEvent forDate: selectedDate) ].
+				action: [ :aBrButton :aBrButtonModel :aBlClickEvent | 
+					self
+						dispatchEvent: (GtCalendarDateClickedEvent new
+								date: selectedDate;
+								clickEvent: aBlClickEvent) ];
+				actionWithModifiers: [ :aBrButton :aBrButtonModel :aBlClickEvent | 
+					self
+						dispatchEvent: (GtCalendarDateClickedEvent new
+								date: selectedDate;
+								clickEvent: aBlClickEvent) ].
 			date = current
 				ifTrue:
 					[ label


### PR DESCRIPTION
Enable dispatching date clicked event even if modifiers are pressed. Forward original BlClickEvent in the custom calendar event so client code can reason about modifiers if needed.